### PR TITLE
Fix issues for XCode Beta 5

### DIFF
--- a/GoogleWearAlert/GoogleWearAlertView/GoogleWearAlert.swift
+++ b/GoogleWearAlert/GoogleWearAlertView/GoogleWearAlert.swift
@@ -45,7 +45,7 @@ class GoogleWearAlert: NSObject {
     let springDamping: CGFloat = 0.6
     let springVelocity: CGFloat = 10
     
-    @lazy var alertQueue: NSMutableArray = NSMutableArray()
+    lazy var alertQueue: NSMutableArray = NSMutableArray()
     var bgWindow: UIWindow = UIWindow();
     weak var defaultViewController:UIViewController?
     var alertActive:Bool = false

--- a/GoogleWearAlert/GoogleWearAlertView/GoogleWearAlertView.swift
+++ b/GoogleWearAlert/GoogleWearAlertView/GoogleWearAlertView.swift
@@ -53,8 +53,8 @@ class GoogleWearAlertView: UIView, UIGestureRecognizerDelegate {
     var iconImage:UIImage?
     
     /** Internal properties needed to resize the view on device rotation properly */
-    @lazy var titleLabel: UILabel = UILabel()
-    @lazy var iconImageView: UIImageView = UIImageView()
+    lazy var titleLabel: UILabel = UILabel()
+    lazy var iconImageView: UIImageView = UIImageView()
     
     /** Inits the notification view. Do not call this from outside this library.
     @param title The text of the notification view
@@ -66,6 +66,10 @@ class GoogleWearAlertView: UIView, UIGestureRecognizerDelegate {
     @param dismissingEnabled Should this message be dismissed when the user taps it?
     */
     
+    required init(coder aDecoder: NSCoder!) {
+	super.init(coder: aDecoder)
+    }
+
     init(title:String, image:UIImage?, type:GoogleWearAlertType, duration:Double, viewController:UIViewController, position:GoogleWearAlertPosition, canbeDismissedByUser:Bool) {
         
         self.title = title


### PR DESCRIPTION
Some things changed with the release of Xcode 5. 
The `@lazy` attribute is now `lazy` and it's also mandatory to override the method `init(coder:)`.